### PR TITLE
Fix for Pool Picker stuck in a loop on Mainnet

### DIFF
--- a/app/P2PWallet/Actions/LookupPools.hs
+++ b/app/P2PWallet/Actions/LookupPools.hs
@@ -9,6 +9,6 @@ import P2PWallet.Data.Core.Internal.Network
 import P2PWallet.Data.Koios.Pool
 import P2PWallet.Prelude
 
-lookupRegisteredPools :: Network -> IO [Pool]
+lookupRegisteredPools :: Network -> IO [PoolList]
 lookupRegisteredPools network = do
   runQueryAllRegisteredPools network >>= fromRightOrAppError

--- a/app/P2PWallet/Data/AppModel/DelegationModel.hs
+++ b/app/P2PWallet/Data/AppModel/DelegationModel.hs
@@ -51,7 +51,7 @@ data DelegationEvent
   -- | Reset Pool Filters.
   | ResetPoolFilters
   -- | Sync all registered pools.
-  | SyncRegisteredPools (ProcessEvent () [Pool])
+  | SyncRegisteredPools (ProcessEvent () [PoolList])
   -- | Add the selected user certificate to the tx builder. The `Text` is the target
   -- pool name so that the GUI can show it on the Builder scene.
   | AddSelectedUserCertificate (Maybe Text,CertificateAction)
@@ -65,7 +65,7 @@ data DelegationEvent
 -------------------------------------------------
 -- | Possible sortings.
 data PoolSortMethod
-  = PoolLiveSaturation SortDirection
+  = PoolActiveSaturation SortDirection
   | PoolActivePledge SortDirection
   | PoolCost SortDirection
   | PoolMargin SortDirection
@@ -82,8 +82,8 @@ data PoolFilterModel = PoolFilterModel
   , sortMethod :: PoolSortMethod
   -- | The required range for the margin value.
   , marginRange :: (Decimal,Decimal)
-  -- | The required range for the live saturation value.
-  , liveSaturationRange :: (Decimal,Decimal)
+  -- | The required range for the active saturation value.
+  , activeSaturationRange :: (Decimal,Decimal)
   -- | The required range for the fixed cost value.
   , fixedCostRange :: (Maybe Decimal,Maybe Decimal)
   -- | The required range for the pledge value.
@@ -95,11 +95,11 @@ makeFieldLabelsNoPrefix ''PoolFilterModel
 instance Default PoolFilterModel where
   def = PoolFilterModel
     { search = ""
-    , sampleSize = 50
+    , sampleSize = 1000
     , currentPage = 0
-    , sortMethod = PoolLiveSaturation SortDescending
+    , sortMethod = PoolActiveSaturation SortDescending
     , marginRange = (0,100)
-    , liveSaturationRange = (0,100)
+    , activeSaturationRange = (0,100)
     , fixedCostRange = (Nothing,Nothing)
     , pledgeRange = (Nothing,Nothing)
     }
@@ -125,7 +125,7 @@ data DelegationModel = DelegationModel
   -- | Whether to show the pool picker.
   , showPoolPicker :: Bool
   -- | The list of registered pools.
-  , registeredPools :: [Pool]
+  , registeredPools :: [PoolList]
   -- | The current filter settings for the stake pools.
   , poolFilterModel :: PoolFilterModel
   -- | Whether to show the pool filter widget.

--- a/app/P2PWallet/Data/Core/Internal/Assets.hs
+++ b/app/P2PWallet/Data/Core/Internal/Assets.hs
@@ -50,7 +50,7 @@ instance ToText Lovelace where
 -- | A type representing Ada values.
 newtype Ada = Ada { unAda :: Decimal }
   deriving (Show)
-  deriving newtype (Eq,Ord,Num,ToText)
+  deriving newtype (Eq,Ord,Num,ToText,Fractional)
 
 instance Printf.PrintfArg Ada where
   formatArg (Ada x) fmt | Printf.fmtChar (Printf.vFmt 'D' fmt) == 'D' =

--- a/app/P2PWallet/Data/Core/Wallets/StakeWallet.hs
+++ b/app/P2PWallet/Data/Core/Wallets/StakeWallet.hs
@@ -31,7 +31,7 @@ data StakeWallet = StakeWallet
   , totalDelegation :: Lovelace
   , utxoBalance :: Lovelace
   , availableRewards :: Lovelace
-  , delegatedPool :: Maybe Pool
+  , delegatedPool :: Maybe PoolInfo
   , delegatedDRep :: Maybe DRep
   , rewardHistory :: [StakeReward]
   , linkedAddresses :: [PaymentAddress]

--- a/app/P2PWallet/Data/Koios/EpochParams.hs
+++ b/app/P2PWallet/Data/Koios/EpochParams.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-
+
+This module has the return types for the https://preprod.koios.rest/#get-/epoch_params API 
+endpoint (the types are the same for mainnet). 
+
+-}
+module P2PWallet.Data.Koios.EpochParams where
+
+import Data.Aeson
+
+import P2PWallet.Prelude
+
+data EpochParams = EpochParams 
+  { optimalPoolCount :: Decimal -- K parameter
+  } deriving (Show,Eq)
+
+makeFieldLabelsNoPrefix ''EpochParams
+
+instance FromJSON EpochParams where
+  parseJSON = withArray "EpochParams" $ \case
+    [obj] -> flip (withObject "EpochParams") obj $ \o -> 
+               EpochParams <$> o .: "optimal_pool_count"
+    _ -> mzero

--- a/app/P2PWallet/Data/Koios/Tokenomics.hs
+++ b/app/P2PWallet/Data/Koios/Tokenomics.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-
+
+This module has the return types for the https://preprod.koios.rest/#get-/totals API 
+endpoint (the types are the same for mainnet). 
+
+-}
+module P2PWallet.Data.Koios.Tokenomics where
+
+import Data.Aeson
+
+import P2PWallet.Data.Core.Internal.Assets
+import P2PWallet.Prelude
+
+data Tokenomics = Tokenomics 
+  { totalSupply :: Lovelace 
+  } deriving (Show,Eq)
+
+makeFieldLabelsNoPrefix ''Tokenomics
+
+instance FromJSON Tokenomics where
+  parseJSON = withArray "Tokenomics" $ \case
+    [obj] -> flip (withObject "Tokenomics") obj $ \o -> 
+               Tokenomics <$> o .: "supply"
+    _ -> mzero

--- a/app/P2PWallet/GUI/HelpMessages.hs
+++ b/app/P2PWallet/GUI/HelpMessages.hs
@@ -286,6 +286,14 @@ liveSaturationMsg = unlines
       ]
   ]
 
+activeSaturationMsg :: Text
+activeSaturationMsg = unlines
+  [ unwords
+      [ "The percent saturation for this pool for the currently active epoch."
+      , "This is NOT the live saturation!"
+      ]
+  ]
+
 activeLinkedAddressesMsg :: Text
 activeLinkedAddressesMsg = unlines
   [ unwords

--- a/app/P2PWallet/GUI/Widgets/Delegation.hs
+++ b/app/P2PWallet/GUI/Widgets/Delegation.hs
@@ -534,9 +534,9 @@ historyTableWidget rewardHistory = do
             ] `styleBasic` [padding 5, bgColor customGray4]
     ] `styleBasic` [ padding 10 ]
 
-poolInfoWidget :: Pool -> AppNode
-poolInfoWidget Pool{..} = do
-    let PoolInfo{..} = fromMaybe def info
+poolInfoWidget :: PoolInfo -> AppNode
+poolInfoWidget PoolInfo{..} = do
+    let PoolMetadata{..} = fromMaybe def info
         nameAndTicker = show $ pretty name <+> tupled [pretty ticker]
     vstack
       [ hstack

--- a/p2p-wallet.cabal
+++ b/p2p-wallet.cabal
@@ -198,6 +198,7 @@ executable p2p-wallet
       P2PWallet.Data.Koios.AddressUTxO
       P2PWallet.Data.Koios.AssetTransaction
       P2PWallet.Data.Koios.BudgetEstimations
+      P2PWallet.Data.Koios.EpochParams
       P2PWallet.Data.Koios.DRep
       P2PWallet.Data.Koios.LinkedPaymentAddresses
       P2PWallet.Data.Koios.MintTransaction
@@ -205,6 +206,7 @@ executable p2p-wallet
       P2PWallet.Data.Koios.PostTypes
       P2PWallet.Data.Koios.StakeAccount
       P2PWallet.Data.Koios.StakeReward
+      P2PWallet.Data.Koios.Tokenomics
       P2PWallet.Data.Koios.Transaction
       P2PWallet.Data.Koios.TxSubmissionResponse
       P2PWallet.Database


### PR DESCRIPTION
While exploring Issue #4, it was discovered that Koios was consistently returning a gateway timeout error when using its `pool_info` [endpoint](https://api.koios.rest/#post-/pool_info). This endpoint was being used to get the "live" stake pool stats such as `live_saturation` and `live_pledge`. However, after [talking](https://github.com/cardano-community/koios-artifacts/issues/310) to the Koios team, it was decided not to use the `pool_info` endpoint for the pool picker because it is too heavy of a query to do in bulk (ie, for all registered pools). Instead, the lighter `pool_list` [endpoint](https://api.koios.rest/#get-/pool_list) was expanded to include `active_stake` so that it could be used instead.

The net impacts for this are:
1. The pool picker no longer gets stuck in a loop.
2. Loading the pool picker is much faster.
3. Live saturation and live pledge are no longer available in the pool picker.
4. The pool picker is more tightly designed around Koios.

Number 3 can be addressed by adding a "see more details" button for the pool in question. (This feature will be addressed in a separate commit/PR).

Number 4 does not have a simple solution. However, looking at what [blockfrost](https://docs.blockfrost.io/#tag/cardano--pools/GET/pools/extended) and [maestro](https://docs.gomaestro.org/cardano/list-registered-stake-pools) offer, they don't even seem to have an equivalent to Koios' `pool_list` endpoint which means they likely can't be used for the pool picker anyway.

(This PR has been tested on the Prepoduction Testnet, but it can't be tested on Mainnet until Koios [v1.3.0](https://github.com/cardano-community/koios-artifacts/releases/tag/v1.3.0) takes effect on Nov 29th - that is when the new `active_stake` field will be available for Mainnet.)